### PR TITLE
Install InSpec standalone, not ChefDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,55 @@
-# Install InSpec on Unix/Linux/Mac
+# How to Install InSpec
 
-## Versioning and State of Development
-This project uses the [Semantic Versioning Policy](https://semver.org/). 
+## Install InSpec on Unix/Linux/Mac
 
-### Branches
-The master branch contains the latest version of the guide up to a new release. 
+### Versioning and State of Development
 
-Other branches contain feature-specific updates to the guide. 
+This project uses the [Semantic Versioning Policy](https://semver.org/).
 
-### Tags
+#### Branches
+
+The master branch contains the latest version of the guide up to a new release.
+
+Other branches contain feature-specific updates to the guide.
+
+#### Tags
+
 Tags indicate official releases of the guide.
 
-Please note 0.x releases are works in progress (WIP) and may change at any time.   
+Please note 0.x releases are works in progress (WIP) and may change at any time.
 
-## Option 1 Install InSpec (Package installer)
+### Option 1: Install InSpec (Package installer)
+
 First things first: We need InSpec on our workstation. For production and standalone environments, I recommend the ChefDK package, since it gives you Chef + Test-Kitchen + InSpec. You can download the package from [https://downloads.chef.io/chefdk](https://downloads.chef.io/chefdk).
 
-## Option 2 Install InSpec (Terminal install)
+### Option 2: Install InSpec (Terminal install)
+
 Another option is to install InSpec via a command line script:
 
 ```
 $ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -channel stable -P chefdk
 ```
 
-## After Install
+### After Install
+
 Once InSpec is installed, run `inspec version` to verify that the installation was successful.
 
+## Install InSpec on Windows
 
-# Install InSpec on Windows
+### Option 1: Package installer
 
-## Option 1 (package installer)
 First things first: We need InSpec on our workstation. For production and standalone environments, I recommend the ChefDK package, since it gives you Chef + Test-Kitchen + InSpec. You can download the package from [https://downloads.chef.io/chefdk](https://downloads.chef.io/chefdk).
 
-## Option 2 (command line)
+### Option 2: Command line
+
 Another option is to install InSpec via a Powershell script:
 
 ```
 $ . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel stable -project chefdk
 ```
 
-## After Install
+### After Install
+
 Once InSpec is installed, run `inspec version` to verify that the installation was successful.
 
 ## NOTICE
@@ -48,10 +58,8 @@ Once InSpec is installed, run `inspec version` to verify that the installation w
 
 Approved for Public Release; Distribution Unlimited. Case Number 18-3678.
 
-## NOTICE
-This software was produced for the U. S. Government under Contract Number HHSM-500-2012-00008I, and is subject to Federal Acquisition Regulation Clause 52.227-14, Rights in Data-General.  
+This software was produced for the U. S. Government under Contract Number HHSM-500-2012-00008I, and is subject to Federal Acquisition Regulation Clause 52.227-14, Rights in Data-General.
 
-No other use other than that granted to the U. S. Government, or to those acting on behalf of the U. S. Government under that Clause is authorized without the express written permission of The MITRE Corporation. 
+No other use other than that granted to the U. S. Government, or to those acting on behalf of the U. S. Government under that Clause is authorized without the express written permission of The MITRE Corporation.
 
 For further information, please contact The MITRE Corporation, Contracts Management Office, 7515 Colshire Drive, McLean, VA  22102-7539, (703) 983-6000.
-

--- a/README.md
+++ b/README.md
@@ -1,51 +1,46 @@
 # How to Install InSpec
 
-## Install InSpec on Unix/Linux/Mac
-
-### Versioning and State of Development
+## Versioning and State of Development
 
 This project uses the [Semantic Versioning Policy](https://semver.org/).
 
-#### Branches
+### Branches
 
 The master branch contains the latest version of the guide up to a new release.
 
 Other branches contain feature-specific updates to the guide.
 
-#### Tags
+### Tags
 
 Tags indicate official releases of the guide.
 
 Please note 0.x releases are works in progress (WIP) and may change at any time.
 
-### Option 1: Install InSpec (Package installer)
+## Instructions
 
-First things first: We need InSpec on our workstation. For production and standalone environments, I recommend the ChefDK package, since it gives you Chef + Test-Kitchen + InSpec. You can download the package from [https://downloads.chef.io/chefdk](https://downloads.chef.io/chefdk).
+First things first, we need InSpec on our workstation. For production and standalone environments, the InSpec omnibus package gives you the bare minimum of what you need. This can be manually installed from a downloaded package or installed using a handy installer script provided by Chef.
 
-### Option 2: Install InSpec (Terminal install)
+### Option 1: Manual installation
 
-Another option is to install InSpec via a command line script:
+This option is best when working in an air-gapped environment. Downloading the latest package files for InSpec from [Chef's downloads page](https://downloads.chef.io/inspec) will allow you to transfer the installers where you need them to go, then, depending on the operating system, install them in the platform-appropriate manner.
 
-```
-$ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -channel stable -P chefdk
-```
+### Option 2: Automated installation
 
-### After Install
+Another option is to install InSpec via a command line script, provided and maintained by Chef. This will only work if your firewall does not restrict WAN access to the following domains:
 
-Once InSpec is installed, run `inspec version` to verify that the installation was successful.
+- `omnitruck.chef.io`
+- `packages.chef.io`
 
-## Install InSpec on Windows
-
-### Option 1: Package installer
-
-First things first: We need InSpec on our workstation. For production and standalone environments, I recommend the ChefDK package, since it gives you Chef + Test-Kitchen + InSpec. You can download the package from [https://downloads.chef.io/chefdk](https://downloads.chef.io/chefdk).
-
-### Option 2: Command line
-
-Another option is to install InSpec via a Powershell script:
+Unix/Linux/Mac:
 
 ```
-$ . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel stable -project chefdk
+$ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -c stable -P inspec -v 3
+```
+
+Windows:
+
+```
+$ . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel stable -project inspec -version 3
 ```
 
 ### After Install


### PR DESCRIPTION
Pursuant to conversation in #1, this is my proposed change to address what may be required under a more tightly controlled installation environment. Centralizing on the omnibus installer is expected no matter the case, rather than mess with Bundler and `gem install` dependency hell.

I believe this will be a more straightforward way of installing the latest version of InSpec (in a given major version) and will have a minimal impact on the system in which it is installed.

I've also included notes to address a possible air-gapped installation requirement and what firewall exceptions might need to be put in place to use the curl-to-bash options.

Did I miss anything? :smile: